### PR TITLE
Reset retryable state after successfully retried, better ergonomics for looping tasks

### DIFF
--- a/addon/-private/retryable-task-instance.js
+++ b/addon/-private/retryable-task-instance.js
@@ -30,7 +30,8 @@ export default class RetryableTaskInstance {
    */
 
   /**
-   * Number of times the task instance has been retried
+   * Number of times the task instance has been retried. This is reset after
+   * the task instance is successfully retried.
    *
    * @property retryCount
    * @type number
@@ -39,7 +40,8 @@ export default class RetryableTaskInstance {
    */
 
   /**
-   * The last error that triggered a retry of the task instance
+   * The last error that triggered a retry of the task instance. This is reset
+   * after the task instance is successfully retried.
    *
    * @property lastError
    * @type Error?
@@ -92,6 +94,8 @@ export default class RetryableTaskInstance {
       if (this._retrySemaphore === EMPTY_RETRIES) {
         triggerHook(this, 'didRetry');
         this._triggerEvent('retried');
+        this.retryCount = 0;
+        this.lastError = null;
       }
 
       return result;

--- a/addon/-private/retryable-task-instance.js
+++ b/addon/-private/retryable-task-instance.js
@@ -97,6 +97,7 @@ export default class RetryableTaskInstance {
 
       if (this._retrySemaphore === EMPTY_RETRIES) {
         this._didRetry();
+        this.taskInstance[RETRYABLE_SYMBOL] = null;
       }
 
       return result;
@@ -112,10 +113,6 @@ export default class RetryableTaskInstance {
 
   _triggerEvent(eventName, ...args) {
     const taskInstance = this.taskInstance;
-
-    // No-op if on an e-c <= 0.8.17
-    if (!taskInstance._triggerEvent) { return; }
-
     const eventArgs = [taskInstance, this, ...args];
     taskInstance._triggerEvent(eventName, ...eventArgs);
   }

--- a/addon/-private/yieldables.js
+++ b/addon/-private/yieldables.js
@@ -3,8 +3,27 @@ import {
   YIELDABLE_CONTINUE
 } from 'ember-concurrency/utils';
 
+export const RETRYABLE_SYMBOL = '__ec_retryable_instance';
+
+
 export const getTaskInstance = {
   [yieldableSymbol](taskInstance, resumeIndex) {
     taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, taskInstance);
   }
 };
+
+const retriedYieldable = {
+  [yieldableSymbol](taskInstance, resumeIndex) {
+    const retryableInstance = taskInstance[RETRYABLE_SYMBOL];
+
+    if (retryableInstance && retryableInstance.retryCount > 0) {
+      retryableInstance._didRetry();
+    }
+
+    taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE);
+  }
+};
+
+export function retried() {
+  return retriedYieldable;
+}

--- a/addon/-private/yieldables.js
+++ b/addon/-private/yieldables.js
@@ -12,7 +12,7 @@ export const getTaskInstance = {
   }
 };
 
-const retriedYieldable = {
+export const retriedSignal = {
   [yieldableSymbol](taskInstance, resumeIndex) {
     const retryableInstance = taskInstance[RETRYABLE_SYMBOL];
 
@@ -23,7 +23,3 @@ const retriedYieldable = {
     taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE);
   }
 };
-
-export function retried() {
-  return retriedYieldable;
-}

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,6 +3,9 @@ export { default as defineModifier } from './define-modifier';
 export { default as Policy } from './policies/base';
 export { default as DelayPolicy } from './policies/delay';
 export { default as ExponentialBackoffPolicy } from './policies/exponential-backoff';
+export {
+  retried
+} from './-private/yieldables';
 
 let ENABLED = true;
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,7 +4,7 @@ export { default as Policy } from './policies/base';
 export { default as DelayPolicy } from './policies/delay';
 export { default as ExponentialBackoffPolicy } from './policies/exponential-backoff';
 export {
-  retried
+  retriedSignal
 } from './-private/yieldables';
 
 let ENABLED = true;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
     this.route('motivation');
     this.route('retry-policies');
     this.route('events');
+    this.route('looping-tasks');
     this.route('testing');
     this.route('api', function() {
       this.route('item', { path: '/*path' });

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -8,6 +8,7 @@
     {{nav.section "Reference"}}
     {{nav.item "Retry Policies" "docs.retry-policies"}}
     {{nav.item "Events" "docs.events"}}
+    {{nav.item "Looping Tasks" "docs.looping-tasks"}}
     {{nav.item "Testing" "docs.testing"}}
   {{/viewer.nav}}
 

--- a/tests/dummy/app/templates/docs/looping-tasks.md
+++ b/tests/dummy/app/templates/docs/looping-tasks.md
@@ -1,0 +1,49 @@
+# Looping Tasks
+
+For looping tasks (e.g. those with `while(true) { ... }`), if the task is retried
+successfully, the next time it fails, it will only be retried if there are
+available delays left in the policy (in the context of `DelayPolicy`-based policies).
+This is counter-intuitive and ideally, successfully retrying the task would
+clear the slate.
+
+Currently, looping tasks hit a version of [the halting problem](https://en.wikipedia.org/wiki/Halting_problem).
+There's no way for ember-concurrency-retryable to know whether the task
+successfully retried, unless it returns (and since it's an infinite loop, it does not.)
+
+To address this problem, ember-concurrency-retryable provides an escape-hatch in
+the form of a "yieldable" called `retriedSignal`. You can `yield` this at the bottom
+of your loop to indicate to ember-concurrency-retryable that the task body has
+been completed, and should be considered "retried".
+
+*Note*: This is the **only** supported use-case for `retriedSignal`. Any other
+use may result in undefined behavior. Please exercise caution when using this
+library-sanctioned leaky abstraction.
+
+```javascript
+// components/flaky-component.js
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import { DelayPolicy, retriedSignal } from 'ember-concurrency-retryable';
+import getWidgetsFromFlakyApi from '../utils/get-widgets';
+import UnavailableError from '../utils/errors/unavailable';
+
+const myDelayPolicy = new DelayPolicy({
+  delay: [300, 600, 1200, 2400],
+  reasons: [UnavailableError]
+});
+
+export default Component.extend({
+  widgetStore: service(),
+
+  widgetPoll: task(function*() {
+    while(true) {
+      const widgets = yield getWidgetsFromFlakyApi();
+      widgetStore.setWidgets(widgets);
+      yield timeout(10000);
+
+      yield retriedSignal;
+    }
+  }).on('init').retryable(myDelayPolicy)
+});
+```

--- a/tests/unit/looping-task-test.js
+++ b/tests/unit/looping-task-test.js
@@ -4,7 +4,7 @@ import EmberObject from '@ember/object';
 import Evented, { on } from '@ember/object/evented';
 import { task } from 'ember-concurrency';
 import { module, test } from 'qunit';
-import { DelayPolicy, retried } from 'ember-concurrency-retryable';
+import { DelayPolicy, retriedSignal } from 'ember-concurrency-retryable';
 import sinon from 'sinon';
 
 module('Unit: looping tasks');
@@ -17,7 +17,7 @@ test("looping tasks do not retain retry state between sets of failures", functio
   let taskAttemptCounter = 0;
 
   const delayPolicy = new DelayPolicy({ delay: [DELAY_MS, DELAY_MS, DELAY_MS] });
-  const retriedStub = sinon.collection.stub();
+  const retriedStub = sinon.stub();
 
   const FAIL_ATTEMPTS = [3, 4, 7, 8];
 
@@ -33,7 +33,7 @@ test("looping tasks do not retain retry state between sets of failures", functio
         }
 
         yield Promise.resolve('stuff happened');
-        yield retried();
+        yield retriedSignal;
       }
     }).drop().evented().retryable(delayPolicy),
 

--- a/tests/unit/looping-task-test.js
+++ b/tests/unit/looping-task-test.js
@@ -1,0 +1,61 @@
+import { run, later } from '@ember/runloop';
+import { Promise } from 'rsvp';
+import EmberObject from '@ember/object';
+import Evented, { on } from '@ember/object/evented';
+import { task } from 'ember-concurrency';
+import { module, test } from 'qunit';
+import { DelayPolicy, retried } from 'ember-concurrency-retryable';
+import sinon from 'sinon';
+
+module('Unit: looping tasks');
+
+test("looping tasks do not retain retry state between sets of failures", function(assert) {
+  assert.expect(5);
+
+  const DELAY_MS = 100;
+  const done = assert.async(1);
+  let taskAttemptCounter = 0;
+
+  const delayPolicy = new DelayPolicy({ delay: [DELAY_MS, DELAY_MS, DELAY_MS] });
+  const retriedStub = sinon.collection.stub();
+
+  const FAIL_ATTEMPTS = [3, 4, 7, 8];
+
+  let Obj = EmberObject.extend(Evented, {
+    doStuff: task(function * () {
+      while (true) {
+        taskAttemptCounter++;
+
+        if (taskAttemptCounter === 9) { return; }
+
+        if (FAIL_ATTEMPTS.includes(taskAttemptCounter)) {
+          throw new Error('solar flare interrupted stuff');
+        }
+
+        yield Promise.resolve('stuff happened');
+        yield retried();
+      }
+    }).drop().evented().retryable(delayPolicy),
+
+    onRetried: on('doStuff:retried', function(_ti, retryableTaskInstance) {
+      assert.equal(retryableTaskInstance.retryCount, 2, 'expected to have required 2 retries');
+      retriedStub();
+    })
+  });
+
+  let obj;
+
+  assert.equal(taskAttemptCounter, 0);
+
+  run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  later(() => {
+    assert.equal(taskAttemptCounter, 9);
+    assert.equal(retriedStub.callCount, 2, 'expected to have successfully retried two sets');
+
+    done();
+  }, (DELAY_MS * 7) + 10);
+});

--- a/tests/unit/state-test.js
+++ b/tests/unit/state-test.js
@@ -1,0 +1,76 @@
+import EmberObject from '@ember/object';
+import Evented, { on } from '@ember/object/evented';
+import { run, later } from '@ember/runloop';
+import { task } from 'ember-concurrency';
+import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
+import sinon from 'sinon';
+import DelayPolicy from 'ember-concurrency-retryable/policies/delay';
+import RetryableTaskInstance from 'ember-concurrency-retryable/-private/retryable-task-instance';
+
+module('Unit: state', function() {
+  test("resets retryable state after task is retried successfully", function(assert) {
+    assert.expect(8);
+
+    const DELAY_MS = 100;
+    const EXPECTED_ERROR = new Error('solar flare interrupted stuff');
+
+    const done = assert.async(1);
+    let taskAttemptCounter = 0;
+    let lastRetryCount = 0;
+    let lastRetryError = null;
+    let lastRetryableInstance = null;
+
+    const delayPolicy = new DelayPolicy({
+      delay: [DELAY_MS, DELAY_MS, DELAY_MS, DELAY_MS]
+    });
+
+    const retriedStub = sinon.stub();
+
+    let Obj = EmberObject.extend(Evented, {
+      doStuff: task(function * () {
+        taskAttemptCounter++;
+
+        if (taskAttemptCounter <= 3) {
+          throw EXPECTED_ERROR;
+        } else {
+          yield Promise.resolve('stuff happened');
+        }
+      }).evented().retryable(delayPolicy),
+
+      onRetried: on('doStuff:retried', function(_ti, retryableTaskInstance) {
+        lastRetryCount = retryableTaskInstance.retryCount;
+        lastRetryError = retryableTaskInstance.lastError;
+        lastRetryableInstance = retryableTaskInstance;
+        retriedStub(_ti, retryableTaskInstance);
+      })
+    });
+
+    let obj, taskInstance;
+
+    assert.equal(taskAttemptCounter, 0);
+
+    run(() => {
+      obj = Obj.create();
+    });
+
+    run(() => {
+      taskInstance = obj.get('doStuff').perform();
+      assert.equal(taskAttemptCounter, 1);
+    });
+
+    later(() => {
+      assert.equal(taskAttemptCounter, 4);
+      assert.ok(retriedStub.calledOnceWith(
+        taskInstance,
+        sinon.match.instanceOf(RetryableTaskInstance)
+      ), 'expected retried callback to have been called once with correct arguments');
+      assert.equal(lastRetryCount, 3, 'retried hook is called before retryCount is reset');
+      assert.equal(lastRetryableInstance.retryCount, 0);
+      assert.equal(lastRetryError, EXPECTED_ERROR, 'retried hook is called before lastError is reset');
+      assert.equal(lastRetryableInstance.lastError, null);
+
+      done();
+    }, ((DELAY_MS * 4) + 10));
+  });
+});


### PR DESCRIPTION
Attempt to address [the awkwardness of e-c-retryable with infinite-looping tasks](https://github.com/maxfierke/ember-concurrency-retryable/issues/2)

Todo:
- [x] Determine whether or not this is actually a good idea
- [x] Docs